### PR TITLE
use glob to retrieve source filenames

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,59 +1,59 @@
 {
-  "name": "banner-cli",
-  "version": "0.10.1",
-  "description": "Create a banner comment from package data.",
-  "homepage": "http://cjpatoilo.com/banner-cli",
-  "repository": "cjpatoilo/banner-cli",
-  "license": "MIT",
-  "author": "CJ Patoilo <cjpatoilo@gmail.com>",
-  "bin": "bin/cli.js",
-  "main": "src/index.js",
-  "files": [
-    "bin/cli.js",
-    "src/index.js"
-  ],
-  "keywords": [
-    "author",
-    "automation",
-    "banner",
-    "bundle",
-    "bundles",
-    "comment",
-    "comments",
-    "contributing",
-    "generate",
-    "generator",
-    "license",
-    "npm",
-    "package.json",
-    "version",
-    "versions"
-  ],
-  "ignore": [
-    ".appveyor.yml",
-    ".editorconfig",
-    ".github",
-    ".gitignore",
-    ".travis.yml"
-  ],
-  "dependencies": {
-    "glob": "^7.1.1",
-    "minimist": "^1.2.0",
-    "prepend-file": "^1.3.1"
-  },
-  "devDependencies": {
-    "ava": "^0.17.0",
-    "editorconfig-tools": "^0.1.1",
-    "eslint": "^3.12.1",
-    "eslint-config-styled": "^0.0.0",
-    "husky": "^0.12.0",
-    "nyc": "^10.0.0"
-  },
-  "engines": {
-    "node": ">=4"
-  },
-  "scripts": {
-    "precommit": "npm t",
-    "test": "nyc ava && eslint . -c styled --ignore-path .gitignore && editorconfig-tools check ."
-  }
+	"name": "banner-cli",
+	"version": "0.10.1",
+	"description": "Create a banner comment from package data.",
+	"homepage": "http://cjpatoilo.com/banner-cli",
+	"repository": "cjpatoilo/banner-cli",
+	"license": "MIT",
+	"author": "CJ Patoilo <cjpatoilo@gmail.com>",
+	"bin": "bin/cli.js",
+	"main": "src/index.js",
+	"files": [
+		"bin/cli.js",
+		"src/index.js"
+	],
+	"keywords": [
+		"author",
+		"automation",
+		"banner",
+		"bundle",
+		"bundles",
+		"comment",
+		"comments",
+		"contributing",
+		"generate",
+		"generator",
+		"license",
+		"npm",
+		"package.json",
+		"version",
+		"versions"
+	],
+	"ignore": [
+		".appveyor.yml",
+		".editorconfig",
+		".github",
+		".gitignore",
+		".travis.yml"
+	],
+	"dependencies": {
+		"glob": "^7.1.1",
+		"minimist": "^1.2.0",
+		"prepend-file": "^1.3.1"
+	},
+	"devDependencies": {
+		"ava": "^0.17.0",
+		"editorconfig-tools": "^0.1.1",
+		"eslint": "^3.12.1",
+		"eslint-config-styled": "^0.0.0",
+		"husky": "^0.12.0",
+		"nyc": "^10.0.0"
+	},
+	"engines": {
+		"node": ">=4"
+	},
+	"scripts": {
+		"precommit": "npm t",
+		"test": "nyc ava && eslint . -c styled --ignore-path .gitignore && editorconfig-tools check ."
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,58 +1,59 @@
 {
-	"name": "banner-cli",
-	"version": "0.10.1",
-	"description": "Create a banner comment from package data.",
-	"homepage": "http://cjpatoilo.com/banner-cli",
-	"repository": "cjpatoilo/banner-cli",
-	"license": "MIT",
-	"author": "CJ Patoilo <cjpatoilo@gmail.com>",
-	"bin": "bin/cli.js",
-	"main": "src/index.js",
-	"files": [
-		"bin/cli.js",
-		"src/index.js"
-	],
-	"keywords": [
-		"author",
-		"automation",
-		"banner",
-		"bundle",
-		"bundles",
-		"comment",
-		"comments",
-		"contributing",
-		"generate",
-		"generator",
-		"license",
-		"npm",
-		"package.json",
-		"version",
-		"versions"
-	],
-	"ignore": [
-		".appveyor.yml",
-		".editorconfig",
-		".github",
-		".gitignore",
-		".travis.yml"
-	],
-	"dependencies": {
-		"minimist": "^1.2.0",
-		"prepend-file": "^1.3.1"
-	},
-	"devDependencies": {
-		"ava": "^0.17.0",
-		"editorconfig-tools": "^0.1.1",
-		"eslint": "^3.12.1",
-		"eslint-config-styled": "^0.0.0",
-		"husky": "^0.12.0",
-		"nyc": "^10.0.0"
-	},
-	"engines": {
-		"node": ">=4"
-	},
-	"scripts": {
-		"precommit": "npm t",
-		"test": "nyc ava && eslint . -c styled --ignore-path .gitignore && editorconfig-tools check ."
-	}
+  "name": "banner-cli",
+  "version": "0.10.1",
+  "description": "Create a banner comment from package data.",
+  "homepage": "http://cjpatoilo.com/banner-cli",
+  "repository": "cjpatoilo/banner-cli",
+  "license": "MIT",
+  "author": "CJ Patoilo <cjpatoilo@gmail.com>",
+  "bin": "bin/cli.js",
+  "main": "src/index.js",
+  "files": [
+    "bin/cli.js",
+    "src/index.js"
+  ],
+  "keywords": [
+    "author",
+    "automation",
+    "banner",
+    "bundle",
+    "bundles",
+    "comment",
+    "comments",
+    "contributing",
+    "generate",
+    "generator",
+    "license",
+    "npm",
+    "package.json",
+    "version",
+    "versions"
+  ],
+  "ignore": [
+    ".appveyor.yml",
+    ".editorconfig",
+    ".github",
+    ".gitignore",
+    ".travis.yml"
+  ],
+  "dependencies": {
+    "glob": "^7.1.1",
+    "minimist": "^1.2.0",
+    "prepend-file": "^1.3.1"
+  },
+  "devDependencies": {
+    "ava": "^0.17.0",
+    "editorconfig-tools": "^0.1.1",
+    "eslint": "^3.12.1",
+    "eslint-config-styled": "^0.0.0",
+    "husky": "^0.12.0",
+    "nyc": "^10.0.0"
+  },
+  "engines": {
+    "node": ">=4"
+  },
+  "scripts": {
+    "precommit": "npm t",
+    "test": "nyc ava && eslint . -c styled --ignore-path .gitignore && editorconfig-tools check ."
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 'use strict'
+const glob = require('glob')
 const prependFile = require('prepend-file')
 const pkg = require(`${process.cwd()}/package.json`)
 
@@ -7,23 +8,26 @@ function banner (options) {
 	options.name = options.name || pkg.name || 'unknown'
 	options.tag = options.tag || pkg.version || '0.0.0'
 	options.homepage = options.homepage || pkg.homepage || `https://npm.com/${options.name}`
-	options.license = options.license || pkg.license || 'unknown'
+	options.license = options.license || pkg.license
 	options.author = options.author || pkg.author.split('<')[0].trim() || ''
 	options.year = options.year || new Date().getFullYear()
 
-	const template = `/*!
+	const template = options.template || `/*!
  * ${options.name.charAt(0).toUpperCase() + options.name.slice(1)} v${options.tag}
  * ${options.homepage}
  *
  * Copyright (c) ${options.year} ${options.author}
- * Licensed under the ${options.license} license
- */\n
+ *${options.license ? ` Licensed under the ${options.license} license\n *` : ''}/\n
 `
 
-	if (!options.source) console.log(`File not found!`)
-	else options.source.map(file => prependFile(file, template))
-
-	process.exit(0)
+	if (!options.source) throw new Error(`File not found!`)
+	else {
+		glob(options.source, (err, files) => {
+			if (err) throw err
+			files.map(file => prependFile(file, template))
+			process.exit(0)
+		})
+	}
 }
 
 module.exports = banner

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function banner (options) {
 	else {
 		glob(options.source, (err, files) => {
 			if (err) throw err
-			files.map(file => prependFile(file, template))
+			files.map(file => prependFile.sync(file, template))
 			process.exit(0)
 		})
 	}


### PR DESCRIPTION
Hello,

I was unable to get this module working with the examples in the README:

> Examples:     $ banner-cli dist/*.js

It implies that the argument can be a glob and is resolved like so, but instead it was just passed as String, which was causing an exception here: 
`options.source.map(file => prependFile(file, template))`

So I added `glob` dependency and use it to get an array of resolved filenames. Now the examples are working for me. I also made possible to add a custom template as option and remove the license part in the default template if no license is provided.